### PR TITLE
Remove commented line before parsing

### DIFF
--- a/CFile.js
+++ b/CFile.js
@@ -1,7 +1,7 @@
 /*
  * CFile.js - plugin to extract resources from a C source code file
  *
- * Copyright © 2019-2020, JEDLSoft
+ * Copyright © 2019-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,6 +87,22 @@ CFile.trimComment = function(commentString) {
     return trimComment;
 }
 
+/**
+ * Remove single and multi-lines comments except for i18n comment style.
+ *
+ * @private
+ * @param {String} string the string to clean
+ * @returns {String} the cleaned string
+ */
+CFile.removeCommentLines = function(data) {
+    if (!data) return;
+    // comment style: // , /* */ single, multi line
+    var trimData = data.replace(/\/\/\s*((?!i18n).)*[$/\n]/g, "").
+                    replace(/\/\*+((?!i18n)[^*]|\*(?!\/))*\*+\//g, "").
+                    replace(/\/\*(((?!i18n).)*)\*\//g, "");
+    return trimData;
+};
+
 var reGetLocString = new RegExp(/\bresBundle_getLocString\(\s*([^"][^,]*|"(\\"|[^"])*")\s*\,\s*"((\\"|[^"])*)"\s*\)/g);
 var reGetLocStringWithKey = new RegExp(/\bresBundle_getLocStringWithKey\(\s*([^"][^,]*|"(\\"|[^"])*")\s*\,\s*"((\\"|[^"])*)"\s*\,\s*"((\\"|[^"])*)"\)/g);
 var reI18nComment = new RegExp(/\/(\*|\/)\s*i18n\s*(.*)($|\*\/)/);
@@ -98,6 +114,8 @@ var reI18nComment = new RegExp(/\/(\*|\/)\s*i18n\s*(.*)($|\*\/)/);
  */
 CFile.prototype.parse = function(data) {
     logger.debug("Extracting strings from " + this.pathName);
+
+    data = CFile.removeCommentLines(data);
     this.resourceIndex = 0;
 
     var comment, match, key;

--- a/CFile.js
+++ b/CFile.js
@@ -98,8 +98,8 @@ CFile.removeCommentLines = function(data) {
     if (!data) return;
     // comment style: // , /* */ single, multi line
     var trimData = data.replace(/\/\/\s*((?!i18n).)*[$/\n]/g, "").
-                    replace(/\/\*+((?!i18n)[^*]|\*(?!\/))*\*+\//g, "").
-                    replace(/\/\*(((?!i18n).)*)\*\//g, "");
+                replace(/\/\*+((?!i18n)[^*]|\*(?!\/))*\*+\//g, "").
+                replace(/\/\*(((?!i18n).)*)\*\//g, "");
     return trimData;
 };
 

--- a/CFileType.js
+++ b/CFileType.js
@@ -1,7 +1,7 @@
 /*
  * CFileType.js - Represents a collection of C files
  *
- * Copyright © 2019-2020, JEDLSoft
+ * Copyright © 2019-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 -ilib-webos-loctool-c is a plugin for the loctool allows it to read and localize c files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.1.0
+* Removed commented lines before parsing so that strings in the comments will not be extracted.
+
 v1.0.1
 * Updated code to print log with log4js.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ v1.0.0
 
 ## License
 
-Copyright © 2019-2020, JEDLSoft
+Copyright © 2019-2021, JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-c",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "main": "./CFileType.js",
     "description": "A loctool plugin that knows how to process C files",
     "license": "Apache-2.0",

--- a/test/assertExtras.js
+++ b/test/assertExtras.js
@@ -1,7 +1,7 @@
 /*
  * assertExtras.js - extra assertion types to use with nodeunit
  *
- * Copyright © 2019-2020, JEDLSoft
+ * Copyright © 2019-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testCFile.js
+++ b/test/testCFile.js
@@ -1,7 +1,7 @@
 /*
  * testCFile.js - test the c file handler object.
  *
- * Copyright © 2019-2020, JEDLSoft
+ * Copyright © 2019-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -412,7 +412,7 @@ module.exports.cfile = {
         });
         test.ok(cf);
 
-        cf.parse('char* alert_btn= (char *)resBundle_getLocString(notification_getResBundle(), "OK"); // i18n  /** Connect WiSA Dongle **/');
+        cf.parse('char* alert_btn= (char *)resBundle_getLocString(notification_getResBundle(), "OK"); // i18n  Connect WiSA Dongle');
 
         var set = cf.getTranslationSet();
         test.ok(set);

--- a/test/testCFile.js
+++ b/test/testCFile.js
@@ -960,8 +960,44 @@ module.exports.cfile = {
         cf.extract();
 
         var set = cf.getTranslationSet();
+        test.equal(set.size(), 2);
+
+        test.done();
+    },
+    testCFileNotParseCommentLine: function(test) {
+        test.expect(3);
+
+        var cf = new CFile({
+            project: p,
+            pathName: undefined,
+            type: cft
+        });
+        test.ok(cf);
+
+        cf.parse('// char* alert_btn= (char *)resBundle_getLocString(notification_getResBundle(), "OK"); // i18n : Power button');
+
+        var set = cf.getTranslationSet();
+        test.ok(set);
         test.equal(set.size(), 0);
 
         test.done();
-    }
+    },
+    testCFileNotParseCommentLine2: function(test) {
+        test.expect(3);
+
+        var cf = new CFile({
+            project: p,
+            pathName: undefined,
+            type: cft
+        });
+        test.ok(cf);
+
+        cf.parse(' char* btn= (char *)resBundle_getLocString(notification_getResBundle(), "CLICK"); /* char* btn2= (char *)resBundle_getLocString(notification_getResBundle(), "OK"); */ ');
+
+        var set = cf.getTranslationSet();
+        test.ok(set);
+        test.equal(set.size(), 1);
+
+        test.done();
+    },
 };

--- a/test/testCFileType.js
+++ b/test/testCFileType.js
@@ -1,7 +1,7 @@
 /*
  * testCFileType.js - test the c file type handler object.
  *
- * Copyright © 2019-2020, JEDLSoft
+ * Copyright © 2019-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testSuite.js
+++ b/test/testSuite.js
@@ -1,7 +1,7 @@
 /*
  * testSuite.js - test suite for this directory
  * 
- * Copyright © 2019-2020, JEDLSoft
+ * Copyright © 2019-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testSuiteFiles.js
+++ b/test/testSuiteFiles.js
@@ -1,7 +1,7 @@
 /*
  * testSuiteFiles.js - list the test files in this directory
  * 
- * Copyright © 2019-2020, JEDLSoft
+ * Copyright © 2019-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testfiles/t1.c
+++ b/test/testfiles/t1.c
@@ -1,126 +1,53 @@
-#include <stdio.h>
-#include "localization.h"
-
-#define	MAXSTRSIZE	512
-
-static char _gSystemLocales[11]={0,};
-static bool _gLocaleDirection=TRUE;
-static ResBundleC *res_bundle = NULL;
-
 static bool _notification_setLocaleDirection(void){
 
-	if(strstr(_gSystemLocales,"ar")!=NULL)
-		return FALSE;
-	else if(strstr(_gSystemLocales,"fa")!=NULL)
-		return FALSE;
-	else if(strstr(_gSystemLocales,"ur")!=NULL)
-		return FALSE;
-	else if(strstr(_gSystemLocales,"he")!=NULL)
-		return FALSE;
-	else if(strstr(_gSystemLocales,"ku")!=NULL)
-		return FALSE;
-	else
-		return TRUE;
+    if(strstr(_gSystemLocales,"ar")!=NULL)
+        return FALSE;
+    else if(strstr(_gSystemLocales,"fa")!=NULL)
+        return FALSE;
+    else if(strstr(_gSystemLocales,"ur")!=NULL)
+        return FALSE;
+    else if(strstr(_gSystemLocales,"he")!=NULL)
+        return FALSE;
+    else if(strstr(_gSystemLocales,"ku")!=NULL)
+        return FALSE;
+    else
+        return TRUE;
 }
 
 static void _notification_setCurrentLocale(const char *locale){
-	snprintf(_gSystemLocales, sizeof(_gSystemLocales), locale);
-	_gLocaleDirection = _notification_setLocaleDirection();
-}
-
-bool notification_getLocaleDirection(void){
-
-	return _gLocaleDirection;
-}
-
-ResBundleC* notification_getResBundle(void){
-
-	return res_bundle;
-}
-
-char* notification_getCurrentLocale(void){
-
-	return _gSystemLocales;
-}
-
-void notification_changeCurrentLocale(const char *locale) {
-
-	const char* file = "cstrings.json";
-	const char* resources_path = "/usr/share/localization/miracast";
-
-	if(locale==NULL)
-		return;
-
-	if(res_bundle != NULL)
-		resBundle_destroy(res_bundle);
-
-	res_bundle = resBundle_createWithRootPath(locale, file, resources_path);
-	_notification_setCurrentLocale(locale);
-
-	return;
+    snprintf(_gSystemLocales, sizeof(_gSystemLocales), locale);
+    _gLocaleDirection = _notification_setLocaleDirection();
 }
 
 void localization(void) {
 
-	char *screen_share_1 = (char *)resBundle_getLocString(res_bundle, "%s requests screen sharing to your TV.<br> Please end the current device's connection to view %s's screen.");
-	char *screen_share_4 = (char *)resBundle_getLocString(res_bundle, "There is an issue with your %s.<br>Please restart it and try again.");
-	char *screen_share_5_1 = (char *)resBundle_getLocString(res_bundle, "The device cannot be connected to your TV.");
-	char *screen_share_5_2 = (char *)resBundle_getLocString(res_bundle, "Please try again. If the issue persists, please restart your TV or check your device.");
-	char *screen_share_8 = (char *)resBundle_getLocString(res_bundle, "[PIN CODE : %s]<br> Enter this PIN code in your %s within 120 seconds.");
-	char *screen_share_19 = (char *)resBundle_getLocString(res_bundle, "The time for entering your \"PIN code\" has expired. Please try again.");
-	char *screen_share_21 = (char *)resBundle_getLocString(res_bundle, "If you accept this request, the current connection with another device will be disconnected.");
-	char *screen_share_22 = (char *)resBundle_getLocString(res_bundle, "Do you want to continue?");
-	char *screen_share_33 = (char *)resBundle_getLocString(res_bundle, "All devices connected via Wi-Fi Direct have been disconnected from TV.");
-	char *screen_share_34 = (char *)resBundle_getLocString(res_bundle, "No");
-	char *screen_share_35 = (char *)resBundle_getLocString(res_bundle, "Yes");
-	char *screen_share_36 = (char *)resBundle_getLocString(res_bundle, "%s requests screen sharing via Wi-Fi Direct.");
-	char *screen_share_37 = (char *)resBundle_getLocString(res_bundle, "Please try again after closing the Screen Share app.");
-	char *screen_share_40 = (char *)resBundle_getLocString(res_bundle, "Overlay Mode is not available during recording or Live Playback.");
-	char *screen_share_41 = (char *)resBundle_getLocString(res_bundle, "\"Overlay Mode\" will be off now to start recording or Live Playback.");
-	char *screen_share_42 = (char *)resBundle_getLocString(res_bundle, "Overlay Mode is not available in {name}.");
-	char *screen_share_43 = (char *)resBundle_getLocString(res_bundle, "Overlay Mode is not available now.");
-	char *screen_share_54 = (char *)resBundle_getLocString(res_bundle, "%s requests screen sharing to your TV.");
-	char *screen_share_58 = (char *)resBundle_getLocString(res_bundle, "OK");
-	char *screen_share_59 = (char *)resBundle_getLocString(res_bundle, "Do you want to \naccept this request?");
-	char *screen_share_60 = (char *)resBundle_getLocString(res_bundle, "Block");
-	char *screen_share_61 = (char *)resBundle_getLocString(res_bundle, "Decline");
-	char *screen_share_62 = (char *)resBundle_getLocString(res_bundle, "Accept");
-	char *screen_share_63 = (char *)resBundle_getLocString(res_bundle, "The screen sharing of %s has stopped.");
-	char *screen_share_64 = (char *)resBundle_getLocString(res_bundle, "%s is blocked.");
-	char *screen_share_66 = (char *)resBundle_getLocString(res_bundle, "If you want to unblock this device, go to 'Settings > Connection > Mobile Connection Management' and delete Screen Share pairing history.");
-	char *screen_share_67 = (char *)resBundle_getLocString(res_bundle, "Cancel");
-	char *screen_share_68 = (char *)resBundle_getLocString(res_bundle, "Unable to connect with Screen Share. Try again.");
-	char *settings_nw_47 = (char *)resBundle_getLocString(res_bundle, "Screen share connection history has been deleted.");
-
-
-	if(screen_share_1)   free(screen_share_1);
-	if(screen_share_4)   free(screen_share_4);
-	if(screen_share_5_1) free(screen_share_5_1);
-	if(screen_share_5_2) free(screen_share_5_2);
-	if(screen_share_8)   free(screen_share_8);
-	if(screen_share_19)  free(screen_share_19);
-	if(screen_share_21)  free(screen_share_21);
-	if(screen_share_22)  free(screen_share_22);
-	if(screen_share_33)  free(screen_share_33);
-	if(screen_share_34)  free(screen_share_34);
-	if(screen_share_35)  free(screen_share_35);
-	if(screen_share_36)  free(screen_share_36);
-	if(screen_share_37)  free(screen_share_37);
-	if(screen_share_40)  free(screen_share_40);
-	if(screen_share_41)  free(screen_share_41);
-	if(screen_share_42)  free(screen_share_42);
-	if(screen_share_43)  free(screen_share_43);
-	if(screen_share_54)  free(screen_share_54);
-	if(screen_share_58)  free(screen_share_58);
-	if(screen_share_59)  free(screen_share_59);
-	if(screen_share_60)  free(screen_share_60);
-	if(screen_share_61)  free(screen_share_61);
-	if(screen_share_62)  free(screen_share_62);
-	if(screen_share_63)  free(screen_share_63);
-	if(screen_share_64)  free(screen_share_64);
-	if(screen_share_66)  free(screen_share_66);
-	if(screen_share_67)  free(screen_share_67);
-	if(screen_share_68)  free(screen_share_68);
-	if(settings_nw_47)   free(settings_nw_47);
+    char *screen_share_1 = (char *)resBundle_getLocString(res_bundle, "%s requests screen sharing to your TV.<br> Please end the current device's connection to view %s's screen.");
+    char *screen_share_4 = (char *)resBundle_getLocString(res_bundle, "There is an issue with your %s.<br>Please restart it and try again.");
+    char *screen_share_5_1 = (char *)resBundle_getLocString(res_bundle, "The device cannot be connected to your TV.");
+    char *screen_share_5_2 = (char *)resBundle_getLocString(res_bundle, "Please try again. If the issue persists, please restart your TV or check your device.");
+    char *screen_share_8 = (char *)resBundle_getLocString(res_bundle, "[PIN CODE : %s]<br> Enter this PIN code in your %s within 120 seconds.");
+    char *screen_share_19 = (char *)resBundle_getLocString(res_bundle, "The time for entering your \"PIN code\" has expired. Please try again.");
+    char *screen_share_21 = (char *)resBundle_getLocString(res_bundle, "If you accept this request, the current connection with another device will be disconnected.");
+    char *screen_share_22 = (char *)resBundle_getLocString(res_bundle, "Do you want to continue?");
+    char *screen_share_33 = (char *)resBundle_getLocString(res_bundle, "All devices connected via Wi-Fi Direct have been disconnected from TV.");
+    char *screen_share_34 = (char *)resBundle_getLocString(res_bundle, "No");
+    char *screen_share_35 = (char *)resBundle_getLocString(res_bundle, "Yes");
+    char *screen_share_36 = (char *)resBundle_getLocString(res_bundle, "%s requests screen sharing via Wi-Fi Direct.");
+    char *screen_share_37 = (char *)resBundle_getLocString(res_bundle, "Please try again after closing the Screen Share app.");
+    char *screen_share_40 = (char *)resBundle_getLocString(res_bundle, "Overlay Mode is not available during recording or Live Playback.");
+    char *screen_share_41 = (char *)resBundle_getLocString(res_bundle, "\"Overlay Mode\" will be off now to start recording or Live Playback.");
+    char *screen_share_42 = (char *)resBundle_getLocString(res_bundle, "Overlay Mode is not available in {name}.");
+    char *screen_share_43 = (char *)resBundle_getLocString(res_bundle, "Overlay Mode is not available now.");
+    char *screen_share_54 = (char *)resBundle_getLocString(res_bundle, "%s requests screen sharing to your TV.");
+    char *screen_share_58 = (char *)resBundle_getLocString(res_bundle, "OK");
+    char *screen_share_59 = (char *)resBundle_getLocString(res_bundle, "Do you want to \naccept this request?");
+    char *screen_share_60 = (char *)resBundle_getLocString(res_bundle, "Block");
+    char *screen_share_61 = (char *)resBundle_getLocString(res_bundle, "Decline");
+    char *screen_share_62 = (char *)resBundle_getLocString(res_bundle, "Accept");
+    char *screen_share_63 = (char *)resBundle_getLocString(res_bundle, "The screen sharing of %s has stopped.");
+    char *screen_share_64 = (char *)resBundle_getLocString(res_bundle, "%s is blocked.");
+    char *screen_share_66 = (char *)resBundle_getLocString(res_bundle, "If you want to unblock this device, go to 'Settings > Connection > Mobile Connection Management' and delete Screen Share pairing history.");
+    char *screen_share_67 = (char *)resBundle_getLocString(res_bundle, "Cancel");
+    char *screen_share_68 = (char *)resBundle_getLocString(res_bundle, "Unable to connect with Screen Share. Try again.");
+    char *settings_nw_47 = (char *)resBundle_getLocString(res_bundle, "Screen share connection history has been deleted.");
 }
-

--- a/test/testfiles/t3.c
+++ b/test/testfiles/t3.c
@@ -1,0 +1,10 @@
+// char *string = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Please say \"Stop\" ");
+
+char *string2 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "You've declined");
+
+/* 
+* char *string3 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "Hello\n\t there"); 
+* char *string4 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "hi\n\t\t there \vwelcome");
+*/
+
+/*char *string5 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "hi\n\t\t there \vwelcome");*/ char *string6 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "hi\n\t\t there \vwelcome");


### PR DESCRIPTION
* Remove commented line before parsing so that strings in the comments will not be extracted.
 When the `i18n` is founded in strings in comments, it treats  `i18n comment style always
```
// i18n comments
/* i18n  comments */
```
* Add test cases and clean up some current test files.
* Update copyright year