### PR TITLE
Strings are not extracted due to incorrect deletion of commented lines

### DIFF
--- a/CFile.js
+++ b/CFile.js
@@ -95,8 +95,8 @@ CFile.removeCommentLines = function(data) {
     if (!data) return;
     // comment style: // , /* */ single, multi line
     var trimData = data.replace(/\/\/\s*((?!i18n).)*[$/\n]/g, "").
-                replace(/\/\*+((?!i18n)[^*]|\*(?!\/))*\*+\//g, "").
-                replace(/\/\*(((?!i18n).)*)\*\//g, "");
+                replace(/\/\*(((?!i18n).)*)\*\//g, "").
+                replace(/\/\*+((?!i18n)[^*]|\*(?!\/))*\*+\//g, "");
     return trimData;
 };
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 
 ## Release Notes
 
+v1.1.7
+* Fixed an issue where strings are not extracted due to incorrect deletion of commented lines.
+
 v1.1.6
 * Updated dependencies. (loctool: 2.16.3)
 * Used the logger provided by the loctool instead of using log4js directly.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-c",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "main": "./CFileType.js",
     "description": "A loctool plugin that knows how to process C files",
     "license": "Apache-2.0",

--- a/test/testCFile.js
+++ b/test/testCFile.js
@@ -960,7 +960,7 @@ module.exports.cfile = {
         cf.extract();
 
         var set = cf.getTranslationSet();
-        test.equal(set.size(), 2);
+        test.equal(set.size(), 4);
 
         test.done();
     },

--- a/test/testfiles/t3.c
+++ b/test/testfiles/t3.c
@@ -8,3 +8,12 @@ char *string2 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "You've dec
 */
 
 /*char *string5 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "hi\n\t\t there \vwelcome");*/ char *string6 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "hi\n\t\t there \vwelcome");
+
+/**********************/
+/* check type         */
+/**********************/
+char *string7 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "More 1");
+/**********************/
+/* check appid        */
+/**********************/
+char *string8 = (gchar*)resBundle_getLocString(_g_res_bundle_object, "More 2");


### PR DESCRIPTION
Strings are not extracted due to incorrect deletion of commented lines
 - Delete a single commented line first and then remove the multi-lines.