### PR TITLE
Add a feature to use common xliff data files for localization

### DIFF
--- a/CFileType.js
+++ b/CFileType.js
@@ -17,11 +17,12 @@
  * limitations under the License.
  */
 
+var fs = require("fs");
+var path = require("path");
 var CFile = require("./CFile.js");
 var JsonResourceFileType = require("ilib-loctool-webos-json-resource");
 var Utils = require("loctool/lib/utils.js")
-var fs = require("fs");
-var path = require("path");
+var ResourceString = require("loctool/lib/ResourceString.js");
 
 var CFileType = function(project) {
     this.type = "c";
@@ -130,9 +131,7 @@ CFileType.prototype.write = function(translations, locales) {
                 db.getResourceByCleanHashKey(res.cleanHashKeyForTranslation(locale), function(err, translated) {
                     var r = translated;
                     if (!translated && this.isloadCommonData) {
-                        var manipulateKey = res.cleanHashKeyForTranslation(locale).
-                                        replace(res.getProject(), this.commonPrjName).
-                                        replace("_" + res.getDataType() + "_", "_" + this.commonPrjType + "_");
+                        var manipulateKey = ResourceString.hashKey(this.commonPrjName, locale, res.getKey(), this.commonPrjType, res.getFlavor());
                         db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
                             if (translated) {
                                 translated.project = res.getProject();

--- a/README.md
+++ b/README.md
@@ -3,8 +3,24 @@
 
 ## Release Notes
 v1.3.0
-* Updated dependencies. (loctool: 2.19.0)
+* Updated dependencies. (loctool: 2.20.0)
 * Added ability to define custom locale inheritance.
+    ~~~~
+       "settings": {
+            "localeInherit": {
+                "en-AU": "en-GB"
+            }
+        }
+    ~~~~
+* Added ability to use common locale data.
+  * App's xliff data has a higher priority, if there's no matched string there, then loctool checks data in the commonXliff directory.
+    ~~~~
+       "settings": {
+            "webos": {
+                "commonXliff": "./common"
+            }
+        }
+    ~~~~
 
 v1.2.0
 * Updated dependencies. (loctool: 2.18.0)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 v1.3.0
 * Updated dependencies. (loctool: 2.20.0)
 * Added ability to define custom locale inheritance.
+  * i.e) en-AU inherits translations from en-GB
     ~~~~
        "settings": {
             "localeInherit": {
@@ -26,6 +27,13 @@ v1.2.0
 * Updated dependencies. (loctool: 2.18.0)
 * Updated to support loctool's generate mode.
 * Added ability to override language default locale.
+    ~~~~
+       "settings": {
+            "localeMap": {
+                "es-CO": "es"
+            }
+        }
+    ~~~~
 
 v1.1.7
 * Updated dependencies. (loctool: 2.17.0)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ilib-loctool-webos-c
--ilib-webos-loctool-c is a plugin for the loctool allows it to read and localize c files. This plugins is optimized for webOS platform.
+ilib-webos-loctool-c is a plugin for the loctool allows it to read and localize c files. This plugins is optimized for webOS platform.
 
 ## Release Notes
 v1.3.0

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "2.19.0",
+        "loctool": "2.20.0",
         "nodeunit": "^0.11.3"
     }
 }


### PR DESCRIPTION
Added ability to use common locale data.
App's xliff data has a higher priority, if there's no matched string there, then loctool checks data in the common directory
depent loctool package version should be `2.20.0` as minumum
  * related PR: https://github.com/iLib-js/loctool/pull/212
  * sample: https://github.com/iLib-js/ilib-loctool-samples/pull/33