### PR TITLE
Fixed some issue cases 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 ilib-webos-loctool-c is a plugin for the loctool allows it to read and localize c files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.4.0
+* Updated to custom locale inheritance feature work properly in generate mode.
+* Added guard code to prevent errors when the common data path is incorrect.
+* Updated to generate resources by comparing base translation data even in generate mode.
+* Fixed an issue where localeinherit related data was not created properly according to the order of locales.
+* Fixed an issue where data is duplicated when it is the same as base translation in generate mode.
+
 v1.3.0
 * Updated dependencies. (loctool: 2.20.0)
 * Added ability to define custom locale inheritance.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-c",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "main": "./CFileType.js",
     "description": "A loctool plugin that knows how to process C files",
     "license": "Apache-2.0",


### PR DESCRIPTION
The same changes have already been reviewed and applied to webos-javascript plugin.
(PR number: 43, 44, 45, 46, 47)

* Updated to custom locale inheritance feature work properly in generate mode.
* Added guard code to prevent errors when the common data path is incorrect.
* Updated to generate resources by comparing base translation data even in generate mode.
* Fixed an issue where localeinherit related data was not created properly according to the order of locales.
* Fixed an issue where data is duplicated when it is the same as base translation in generate mode.
* Updated sample app: https://github.com/iLib-js/ilib-loctool-samples/pull/41