### PR TITLE
Updated not to load common data repeatedly if it's loaded from another plugin in a project

### DIFF
--- a/CFileType.js
+++ b/CFileType.js
@@ -125,9 +125,16 @@ CFileType.prototype.write = function(translations, locales) {
             return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale;
         }.bind(this));
 
-    if (this.commonPath && !this.isloadCommonData) {
-        this._loadCommonXliff();
+    if ((typeof(translations) !== 'undefined') && (typeof(translations.getProjects()) !== 'undefined') && (translations.getProjects().indexOf("common") !== -1)) {
         this.isloadCommonData = true;
+    }
+    if (this.commonPath) {
+        if (!this.isloadCommonData) {
+            this._loadCommonXliff();
+            this.isloadCommonData = true;
+        } else {
+            this._addComonDatatoTranslationSet(translations);
+        }
     }
 
     if (mode === "localize") {
@@ -354,6 +361,18 @@ CFileType.prototype._loadCommonXliff = function() {
         }.bind(this));
     }
 };
+
+CFileType.prototype._addComonDatatoTranslationSet = function(tsdata) {
+    var prots = this.project.getRepository().getTranslationSet();
+    var commonts = tsdata.getBy({project: "common"});
+    if (commonts.length > 0){
+        this.commonPrjName = commonts[0].getProject();
+        this.commonPrjType = commonts[0].getDataType();
+        commonts.forEach(function(ts){
+            prots.add(ts);
+        }.bind(this));
+    }
+}
 
 CFileType.prototype.newFile = function(path) {
     return new CFile({

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ ilib-webos-loctool-c is a plugin for the loctool allows it to read and localize 
 v1.6.0
 * Fixed an issue where didn't handle single quotes properly.
 * Supported pseudo localization.
+* Updated not to load common data repeatedly if it's loaded from another plugin in a project.
 
 v1.5.2
 * Updated dependencies.


### PR DESCRIPTION
* Updated not to load common data repeatedly if it's loaded from another plugin in a project.
  * Implemented not to load/read common data files if it's already loaded. only add data to the translation set.
  * Same changes like other webos plugin